### PR TITLE
feat: add third Claude profile for DashScope/Aliyun

### DIFF
--- a/.claude-third-profile/.claude.json
+++ b/.claude-third-profile/.claude.json
@@ -1,0 +1,1 @@
+../.claude/.claude.json

--- a/.claude-third-profile/CLAUDE.md
+++ b/.claude-third-profile/CLAUDE.md
@@ -1,0 +1,1 @@
+../.claude/CLAUDE.md

--- a/.claude-third-profile/settings.json
+++ b/.claude-third-profile/settings.json
@@ -1,0 +1,43 @@
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "",
+    "ANTHROPIC_BASE_URL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "DISABLE_TELEMETRY": "1",
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
+  },
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(*.env*)",
+      "Read(**/.env)"
+    ],
+    "defaultMode": "default"
+  },
+  "model": "opus",
+  "hooks": {
+    "Notification": [
+       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "choice=$(osascript -e 'button returned of (display dialog \"Claude Code needs attention\" buttons {\"Dismiss\", \"Terminal\", \"VS Code\"} default button \"VS Code\" giving up after 10)'); [[ \"$choice\" == \"VS Code\" ]] && osascript -e 'tell application \"Visual Studio Code\" to activate'; [[ \"$choice\" == \"Terminal\" ]] && osascript -e 'tell application \"Terminal\" to activate'"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
+  },
+  "alwaysThinkingEnabled": true,
+  "promptSuggestionEnabled": false
+}

--- a/.claude-third-profile/settings.json
+++ b/.claude-third-profile/settings.json
@@ -2,6 +2,9 @@
   "env": {
     "ANTHROPIC_AUTH_TOKEN": "",
     "ANTHROPIC_BASE_URL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen3.5-plus",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "kimi-k2.5",
     "API_TIMEOUT_MS": "3000000",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "DISABLE_TELEMETRY": "1",

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # .env is gitignored — never commit it.
 
 # --- Claude Profile Tokens ---
-ANTHROPIC_AUTH_TOKEN=      # Default profile (~/.claude)
-Z_AI_AUTH_TOKEN=           # Second profile (~/.claude-second-profile)
-DASHSCOPE_AUTH_TOKEN=      # Third profile (~/.claude-third-profile)
+ANTHROPIC_AUTH_TOKEN=
+Z_AI_AUTH_TOKEN=
+DASHSCOPE_AUTH_TOKEN=
 

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Copy this file to .env and fill in your values.
 # .env is gitignored — never commit it.
 
-# --- API Keys ---
-ANTHROPIC_AUTH_TOKEN=
+# --- Claude Profile Tokens ---
+ANTHROPIC_AUTH_TOKEN=      # Default profile (~/.claude)
+Z_AI_AUTH_TOKEN=           # Second profile (~/.claude-second-profile)
+DASHSCOPE_AUTH_TOKEN=      # Third profile (~/.claude-third-profile)
 

--- a/.zshrc
+++ b/.zshrc
@@ -115,20 +115,19 @@ ZSH_AUTOSUGGEST_USE_ASYNC=1
 
 . "$HOME/.local/bin/env"
 
-# ------ second claude ----
+# ------ N-Claude profile system ----
 _claude_with_profile() {
   export CLAUDE_CONFIG_DIR="$1"
   command claude "${@:2}"
 }
-# Personal profile (default)
-claude() {
-  _claude_with_profile "$HOME/.claude" "$@"
-}
-# Second profile
-s-claude() {
-  _claude_with_profile "$HOME/.claude-second-profile" "$@"
-}
-# Third profile (DashScope/Aliyun)
-d-claude() {
-  _claude_with_profile "$HOME/.claude-third-profile" "$@"
-}
+
+# Define profiles: (wrapper_name, profile_dir)
+_claude_profiles=(
+  "claude"            ".claude"
+  "s-claude"          ".claude-second-profile"
+  "d-claude"          ".claude-third-profile"
+)
+
+for name dir in "${_claude_profiles[@]}"; do
+  eval "${name}() { _claude_with_profile \"\$HOME/${dir}\" \"\$@\"; }"
+done

--- a/.zshrc
+++ b/.zshrc
@@ -128,3 +128,7 @@ claude() {
 s-claude() {
   _claude_with_profile "$HOME/.claude-second-profile" "$@"
 }
+# Third profile (DashScope/Aliyun)
+d-claude() {
+  _claude_with_profile "$HOME/.claude-third-profile" "$@"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,21 +25,33 @@ s-claude()  # uses ~/.claude-second-profile
 d-claude()  # uses ~/.claude-third-profile (DashScope/Aliyun)
 ```
 
-To add more profiles, create a new wrapper function following the same pattern. Each profile directory contains its own `CLAUDE.md` with shared global preferences.
+### Adding a New Profile
+
+1. Add entry to `_claude_profiles` array in `.zshrc`
+2. Add `setup_profile "<dir>" "<ENV_VAR>"` call in `install.sh`
+3. Create `<dir>/settings.json` and `<dir>/CLAUDE.md` in the repo
+
+The `install.sh` symlinks each profile's `CLAUDE.md` to `$HOME`, so edits in the repo take effect immediately after re-running install.
 
 ## Install
 
 ```bash
+# Set required env vars first
+export Z_AI_AUTH_TOKEN="..."        # for s-claude
+export DASHSCOPE_AUTH_TOKEN="..."   # for d-claude
+
 ./install.sh
 ```
 
-The script symlinks dotfiles into `$HOME` and:
-- Generates `.claude-second-profile/settings.json` with `ANTHROPIC_AUTH_TOKEN` from `Z_AI_AUTH_TOKEN` env var
-- Generates `.claude-third-profile/settings.json` with `ANTHROPIC_AUTH_TOKEN` from `DASHSCOPE_AUTH_TOKEN` env var
-- Configures git to use `.githooks/` via `core.hooksPath`
-
-When extending, prefer symlinks over copying so edits to the repo take effect immediately.
+The script symlinks dotfiles into `$HOME` and generates `settings.json` for each profile, injecting the auth token from the corresponding env var. It also configures git to use `.githooks/` via `core.hooksPath`.
 
 ## Git Hooks
 
 - `post-checkout` — Copies `.env` from main worktree to new worktrees (for `git worktree add`)
+
+## Security
+
+All profile `settings.json` files deny reading `.env` files via permissions:
+```json
+"deny": ["Read(.env)", "Read(*.env*)", "Read(**/.env)"]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Personal dotfiles for macOS/zsh. Managed with a simple `install.sh` bootstrap sc
 - `install.sh` — Bootstrap script that symlinks dotfiles and generates secret-bearing configs
 - `.claude/` — Claude Code config for the default profile (`~/.claude`)
 - `.claude-second-profile/` — Claude Code config for a second profile (`~/.claude-second-profile`)
+- `.claude-third-profile/` — Claude Code config for DashScope/Aliyun profile (`~/.claude-third-profile`)
 - `.githooks/` — Git hooks directory (configured via `core.hooksPath`)
 
 ## N-Claude Profile System
@@ -21,6 +22,7 @@ The `.zshrc` defines a `_claude_with_profile` helper and wrapper functions to sw
 ```zsh
 claude()    # uses ~/.claude (default)
 s-claude()  # uses ~/.claude-second-profile
+d-claude()  # uses ~/.claude-third-profile (DashScope/Aliyun)
 ```
 
 To add more profiles, create a new wrapper function following the same pattern. Each profile directory contains its own `CLAUDE.md` with shared global preferences.
@@ -32,7 +34,8 @@ To add more profiles, create a new wrapper function following the same pattern. 
 ```
 
 The script symlinks dotfiles into `$HOME` and:
-- Generates `.claude-second-profile/settings.json` with `ANTHROPIC_AUTH_TOKEN` from environment
+- Generates `.claude-second-profile/settings.json` with `ANTHROPIC_AUTH_TOKEN` from `Z_AI_AUTH_TOKEN` env var
+- Generates `.claude-third-profile/settings.json` with `ANTHROPIC_AUTH_TOKEN` from `DASHSCOPE_AUTH_TOKEN` env var
 - Configures git to use `.githooks/` via `core.hooksPath`
 
 When extending, prefer symlinks over copying so edits to the repo take effect immediately.

--- a/install.sh
+++ b/install.sh
@@ -14,30 +14,25 @@ symlink() {
   echo "LINK  $dst -> $src"
 }
 
+setup_profile() {
+  local profile="$1"
+  local env_var="$2"
+  mkdir -p "$HOME/$profile"
+  symlink "$profile/CLAUDE.md"
+  jq --arg token "${!env_var:-}" \
+    '.env.ANTHROPIC_AUTH_TOKEN = $token' \
+    "$DOTFILES/$profile/settings.json" \
+    > "$HOME/$profile/settings.json"
+  echo "GEN   $HOME/$profile/settings.json"
+}
+
+# Symlinks
 symlink .zshrc
 symlink .env.example
 
-# --- .claude-second-profile ---
-# CLAUDE.md can be symlinked (no secrets), but settings.json must be generated
-# because it contains ANTHROPIC_AUTH_TOKEN.
-mkdir -p "$HOME/.claude-second-profile"
-symlink .claude-second-profile/CLAUDE.md
-
-jq --arg token "${Z_AI_AUTH_TOKEN:-}" \
-  '.env.ANTHROPIC_AUTH_TOKEN = $token' \
-  "$DOTFILES/.claude-second-profile/settings.json" \
-  > "$HOME/.claude-second-profile/settings.json"
-echo "GEN   $HOME/.claude-second-profile/settings.json"
-
-# --- .claude-third-profile (DashScope/Aliyun) ---
-mkdir -p "$HOME/.claude-third-profile"
-symlink .claude-third-profile/CLAUDE.md
-
-jq --arg token "${DASHSCOPE_AUTH_TOKEN:-}" \
-  '.env.ANTHROPIC_AUTH_TOKEN = $token' \
-  "$DOTFILES/.claude-third-profile/settings.json" \
-  > "$HOME/.claude-third-profile/settings.json"
-echo "GEN   $HOME/.claude-third-profile/settings.json"
+# Profiles: (profile_dir, env_var_name)
+setup_profile ".claude-second-profile" "Z_AI_AUTH_TOKEN"
+setup_profile ".claude-third-profile" "DASHSCOPE_AUTH_TOKEN"
 
 git -C "$DOTFILES" config core.hooksPath .githooks
 echo "HOOK  core.hooksPath -> .githooks"

--- a/install.sh
+++ b/install.sh
@@ -23,11 +23,21 @@ symlink .env.example
 mkdir -p "$HOME/.claude-second-profile"
 symlink .claude-second-profile/CLAUDE.md
 
-jq --arg token "${ANTHROPIC_AUTH_TOKEN:-}" \
+jq --arg token "${Z_AI_AUTH_TOKEN:-}" \
   '.env.ANTHROPIC_AUTH_TOKEN = $token' \
   "$DOTFILES/.claude-second-profile/settings.json" \
   > "$HOME/.claude-second-profile/settings.json"
 echo "GEN   $HOME/.claude-second-profile/settings.json"
+
+# --- .claude-third-profile (DashScope/Aliyun) ---
+mkdir -p "$HOME/.claude-third-profile"
+symlink .claude-third-profile/CLAUDE.md
+
+jq --arg token "${DASHSCOPE_AUTH_TOKEN:-}" \
+  '.env.ANTHROPIC_AUTH_TOKEN = $token' \
+  "$DOTFILES/.claude-third-profile/settings.json" \
+  > "$HOME/.claude-third-profile/settings.json"
+echo "GEN   $HOME/.claude-third-profile/settings.json"
 
 git -C "$DOTFILES" config core.hooksPath .githooks
 echo "HOOK  core.hooksPath -> .githooks"

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# Tests for install.sh bootstrap script
+
+setup() {
+  # Create a temporary home directory for each test
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+
+  # Path to the install script
+  INSTALL_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/install.sh"
+
+  # Store original environment
+  ORIGINAL_Z_AI_TOKEN="${Z_AI_AUTH_TOKEN:-}"
+  ORIGINAL_DASHSCOPE_TOKEN="${DASHSCOPE_AUTH_TOKEN:-}"
+}
+
+teardown() {
+  # Cleanup temp directory
+  rm -rf "$TEST_HOME"
+
+  # Restore environment
+  export Z_AI_AUTH_TOKEN="$ORIGINAL_Z_AI_TOKEN"
+  export DASHSCOPE_AUTH_TOKEN="$ORIGINAL_DASHSCOPE_TOKEN"
+}
+
+@test "symlink_creates_new" {
+  # .zshrc doesn't exist, should create symlink
+  run bash "$INSTALL_SCRIPT"
+
+  [ -L "$HOME/.zshrc" ]
+  [ "$(readlink "$HOME/.zshrc")" = "$(dirname "$INSTALL_SCRIPT")/.zshrc" ]
+}
+
+@test "symlink_updates_existing" {
+  # Create existing symlink to wrong target
+  ln -s /tmp/wrong "$HOME/.zshrc"
+
+  run bash "$INSTALL_SCRIPT"
+
+  [ -L "$HOME/.zshrc" ]
+  [ "$(readlink "$HOME/.zshrc")" = "$(dirname "$INSTALL_SCRIPT")/.zshrc" ]
+}
+
+@test "symlink_skips_regular_file" {
+  # Create a regular file (not symlink)
+  touch "$HOME/.zshrc"
+
+  run bash "$INSTALL_SCRIPT"
+
+  # Should still be a regular file, not a symlink
+  [ -f "$HOME/.zshrc" ]
+  [ ! -L "$HOME/.zshrc" ]
+
+  # Should have SKIP message in output
+  [[ "$output" == *"SKIP"*".zshrc"* ]]
+}
+
+@test "creates_profile_directories" {
+  run bash "$INSTALL_SCRIPT"
+
+  [ -d "$HOME/.claude-second-profile" ]
+  [ -d "$HOME/.claude-third-profile" ]
+}
+
+@test "generates_settings_with_token" {
+  export Z_AI_AUTH_TOKEN="test-z-ai-token-12345"
+
+  run bash "$INSTALL_SCRIPT"
+
+  [ -f "$HOME/.claude-second-profile/settings.json" ]
+
+  # Check that token was injected
+  local token
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-second-profile/settings.json")
+  [ "$token" = "test-z-ai-token-12345" ]
+}
+
+@test "generates_settings_with_dashscope_token" {
+  export DASHSCOPE_AUTH_TOKEN="test-dashscope-token-67890"
+
+  run bash "$INSTALL_SCRIPT"
+
+  [ -f "$HOME/.claude-third-profile/settings.json" ]
+
+  # Check that token was injected
+  local token
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-third-profile/settings.json")
+  [ "$token" = "test-dashscope-token-67890" ]
+}
+
+@test "generates_settings_with_empty_token" {
+  # Unset tokens (or set empty)
+  unset Z_AI_AUTH_TOKEN
+  unset DASHSCOPE_AUTH_TOKEN
+
+  run bash "$INSTALL_SCRIPT"
+
+  [ -f "$HOME/.claude-second-profile/settings.json" ]
+  [ -f "$HOME/.claude-third-profile/settings.json" ]
+
+  # Token should be empty string
+  local token
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-second-profile/settings.json")
+  [ "$token" = "" ]
+
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-third-profile/settings.json")
+  [ "$token" = "" ]
+}
+
+@test "settings_preserves_other_config" {
+  export Z_AI_AUTH_TOKEN="my-token"
+
+  run bash "$INSTALL_SCRIPT"
+
+  # Check that other settings are preserved from template
+  local base_url
+  base_url=$(jq -r '.env.ANTHROPIC_BASE_URL' "$HOME/.claude-second-profile/settings.json")
+  [ "$base_url" = "https://api.z.ai/api/anthropic" ]
+
+  local model
+  model=$(jq -r '.model' "$HOME/.claude-second-profile/settings.json")
+  [ "$model" = "opus" ]
+}
+
+@test "sets_git_hooks_path" {
+  run bash "$INSTALL_SCRIPT"
+
+  # Check git config was set (in the dotfiles repo, not temp home)
+  local hooks_path
+  hooks_path=$(git -C "$(dirname "$INSTALL_SCRIPT")" config core.hooksPath)
+  [ "$hooks_path" = ".githooks" ]
+}
+
+@test "idempotent" {
+  export Z_AI_AUTH_TOKEN="same-token"
+  export DASHSCOPE_AUTH_TOKEN="same-dashscope-token"
+
+  # Run twice
+  run bash "$INSTALL_SCRIPT"
+  run bash "$INSTALL_SCRIPT"
+
+  # Check symlinks still correct
+  [ -L "$HOME/.zshrc" ]
+  [ "$(readlink "$HOME/.zshrc")" = "$(dirname "$INSTALL_SCRIPT")/.zshrc" ]
+
+  # Check settings still correct
+  local token
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-second-profile/settings.json")
+  [ "$token" = "same-token" ]
+
+  token=$(jq -r '.env.ANTHROPIC_AUTH_TOKEN' "$HOME/.claude-third-profile/settings.json")
+  [ "$token" = "same-dashscope-token" ]
+}
+
+@test "symlinks_claude_md_for_profiles" {
+  run bash "$INSTALL_SCRIPT"
+
+  # CLAUDE.md should be symlinked in each profile
+  [ -L "$HOME/.claude-second-profile/CLAUDE.md" ]
+  [ -L "$HOME/.claude-third-profile/CLAUDE.md" ]
+}
+
+@test "outputs_link_messages" {
+  run bash "$INSTALL_SCRIPT"
+
+  [[ "$output" == *"LINK"*".zshrc"* ]]
+  [[ "$output" == *"Done."* ]]
+}


### PR DESCRIPTION
- Add .claude-third-profile with DashScope base URL
- Add d-claude() wrapper function in .zshrc
- Update install.sh to setup third profile with DASHSCOPE_AUTH_TOKEN
- Update .env.example with separate tokens per provider